### PR TITLE
RNMT-2655 Update supported plugins to use "implementation" instead of "compile" on gradle

### DIFF
--- a/OneSignalSDK/app/build.gradle
+++ b/OneSignalSDK/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:12.0.0'
 
     // For Chrome tabs
-    compile 'com.android.support:customtabs:27.1.0'
+    api 'com.android.support:customtabs:27.1.0'
 }
 
 //apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updated usage of compile to implementation/api in gradle dependencies.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-2655

<!--- Why is this change required? What problem does it solve? -->
The compile function and its associates have been deprecated in gradle. Their usages should be updated to api or implementation or their associates.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Ran the unit tests from each core plugin.

Made some exploratory tests:
 - Tested every affected sample app
 - Tested both test apps
 - Tested an app without any additional plugins
 - Tested using MABS 4.0 and 4.1

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly