### PR TITLE
revert: partial revert of #773fdfb

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     // Required for GoogleApiAvailability
     implementation 'com.google.android.gms:play-services-base:12.0.1'
 
-    api 'com.android.support:support-v4:28.0.0'
-    api 'com.android.support:customtabs:28.0.0'
+    api 'com.android.support:support-v4:27.1.1'
+    api 'com.android.support:customtabs:27.1.1'
 
     // Change api to implementation. Need to check however this has any effect in production
     //   projects that pull from maven.


### PR DESCRIPTION
This PR partially reverts changes affecting support library version so that they come directly from upstream as they will be overridden at the plugin level in the context of the RNMT-3266

References https://outsystemsrd.atlassian.net/browse/RNMT-3266