### PR TITLE
RMET-1495 Android >= 12 Trampoline

### DIFF
--- a/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
@@ -67,7 +67,11 @@
             android:excludeFromRecents="true"
             android:taskAffinity=""
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
-            android:exported="true" />
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+        </activity>
 
         <service
             android:name="com.onesignal.HmsMessageServiceOneSignal"

--- a/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
+++ b/OneSignalSDK/onesignal/src/main/AndroidManifest.xml
@@ -61,8 +61,13 @@
 
     <application>
 
-        <receiver android:name="com.onesignal.NotificationOpenedReceiver"
-            android:exported="true"/>
+        <activity
+            android:name="com.onesignal.NotificationOpenedReceiver"
+            android:noHistory="true"
+            android:excludeFromRecents="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:exported="true" />
 
         <service
             android:name="com.onesignal.HmsMessageServiceOneSignal"

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -184,7 +184,7 @@ class GenerateNotification {
    }
 
    private static PendingIntent getNewDismissActionPendingIntent(int requestCode, Intent intent) {
-      return PendingIntent.getBroadcast(currentContext, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+      return PendingIntent.getBroadcast(currentContext, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
    }
 
    private static Intent getNewBaseIntent(int notificationId) {

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/GenerateNotification.java
@@ -77,11 +77,11 @@ class GenerateNotification {
    //   notification Intent.
    public static final String BUNDLE_KEY_ONESIGNAL_DATA = "onesignalData";
 
+   private static final Class<?> notificationOpenedClass = NotificationOpenedReceiver.class;
+   private static final Class<?> notificationDismissedClass = NotificationDismissReceiver.class;
+   private static Resources contextResources = null;
    private static Context currentContext = null;
    private static String packageName = null;
-   private static Resources contextResources = null;
-   private static Class<?> notificationOpenedClass;
-   private static boolean openerIsBroadcast;
 
    private static class OneSignalNotificationBuilder {
       NotificationCompat.Builder compatBuilder;
@@ -92,16 +92,6 @@ class GenerateNotification {
       currentContext = inContext;
       packageName = currentContext.getPackageName();
       contextResources = currentContext.getResources();
-
-      PackageManager packageManager = currentContext.getPackageManager();
-      Intent intent = new Intent(currentContext, NotificationOpenedReceiver.class);
-      intent.setPackage(currentContext.getPackageName());
-      if (packageManager.queryBroadcastReceivers(intent, 0).size() > 0) {
-         openerIsBroadcast = true;
-         notificationOpenedClass = NotificationOpenedReceiver.class;
-      }
-      else
-         notificationOpenedClass = NotificationOpenedActivity.class;
    }
 
    static void fromJsonPayload(NotificationGenerationJob notifJob) {
@@ -190,28 +180,23 @@ class GenerateNotification {
    }
 
    private static PendingIntent getNewActionPendingIntent(int requestCode, Intent intent) {
-      if (openerIsBroadcast)
-         return PendingIntent.getBroadcast(currentContext, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
       return PendingIntent.getActivity(currentContext, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
    }
 
-   private static Intent getNewBaseIntent(int notificationId) {
-      Intent intent = new Intent(currentContext, notificationOpenedClass)
-                        .putExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, notificationId);
-
-      if (openerIsBroadcast)
-         return intent;
-      return intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+   private static PendingIntent getNewDismissActionPendingIntent(int requestCode, Intent intent) {
+      return PendingIntent.getBroadcast(currentContext, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
    }
 
-   private static Intent getNewBaseDeleteIntent(int notificationId) {
-      Intent intent = new Intent(currentContext, notificationOpenedClass)
-          .putExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, notificationId)
-          .putExtra("dismissed", true);
-      
-      if (openerIsBroadcast)
-         return intent;
-      return intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK | Intent.FLAG_ACTIVITY_NO_ANIMATION);
+   private static Intent getNewBaseIntent(int notificationId) {
+      return new Intent(currentContext, notificationOpenedClass)
+              .putExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, notificationId)
+              .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+   }
+
+   private static Intent getNewBaseDismissIntent(int notificationId) {
+      return new Intent(currentContext, notificationDismissedClass)
+              .putExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, notificationId)
+              .putExtra("dismissed", true);
    }
    
    private static OneSignalNotificationBuilder getBaseOneSignalNotificationBuilder(NotificationGenerationJob notifJob) {
@@ -383,8 +368,9 @@ class GenerateNotification {
          else
             createSummaryNotification(notifJob, oneSignalNotificationBuilder);
       }
-      else
+      else {
          notification = createGenericPendingIntentsForNotif(notifBuilder, gcmBundle, notificationId);
+      }
 
       // NotificationManagerCompat does not auto omit the individual notification on the device when using
       //   stacked notifications on Android 4.2 and older
@@ -402,7 +388,7 @@ class GenerateNotification {
       Random random = new SecureRandom();
       PendingIntent contentIntent = getNewActionPendingIntent(random.nextInt(), getNewBaseIntent(notificationId).putExtra(BUNDLE_KEY_ONESIGNAL_DATA, gcmBundle.toString()));
       notifBuilder.setContentIntent(contentIntent);
-      PendingIntent deleteIntent = getNewActionPendingIntent(random.nextInt(), getNewBaseDeleteIntent(notificationId));
+      PendingIntent deleteIntent = getNewDismissActionPendingIntent(random.nextInt(), getNewBaseDismissIntent(notificationId));
       notifBuilder.setDeleteIntent(deleteIntent);
       return notifBuilder.build();
    }
@@ -411,14 +397,13 @@ class GenerateNotification {
       Random random = new SecureRandom();
       PendingIntent contentIntent = getNewActionPendingIntent(random.nextInt(), getNewBaseIntent(notificationId).putExtra(BUNDLE_KEY_ONESIGNAL_DATA, gcmBundle.toString()).putExtra("grp", group));
       notifBuilder.setContentIntent(contentIntent);
-      PendingIntent deleteIntent = getNewActionPendingIntent(random.nextInt(), getNewBaseDeleteIntent(notificationId).putExtra("grp", group));
+      PendingIntent deleteIntent = getNewDismissActionPendingIntent(random.nextInt(), getNewBaseDismissIntent(notificationId).putExtra("grp", group));
       notifBuilder.setDeleteIntent(deleteIntent);
       notifBuilder.setGroup(group);
 
       try {
          notifBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
-      }
-      catch (Throwable t) {
+      } catch (Throwable t) {
          //do nothing in this case...Android support lib 26 isn't in the project
       }
    }
@@ -515,7 +500,7 @@ class GenerateNotification {
       String group = gcmBundle.optString("grp", null);
 
       SecureRandom random = new SecureRandom();
-      PendingIntent summaryDeleteIntent = getNewActionPendingIntent(random.nextInt(), getNewBaseDeleteIntent(0).putExtra("summary", group));
+      PendingIntent summaryDeleteIntent = getNewDismissActionPendingIntent(random.nextInt(), getNewBaseDismissIntent(0).putExtra("summary", group));
       
       Notification summaryNotification;
       Integer summaryNotificationId = null;
@@ -720,7 +705,7 @@ class GenerateNotification {
       int summaryNotificationId = OneSignalNotificationManager.getGrouplessSummaryId();
 
       PendingIntent summaryContentIntent = getNewActionPendingIntent(random.nextInt(), createBaseSummaryIntent(summaryNotificationId, gcmBundle, group));
-      PendingIntent summaryDeleteIntent = getNewActionPendingIntent(random.nextInt(), getNewBaseDeleteIntent(0).putExtra("summary", group));
+      PendingIntent summaryDeleteIntent = getNewDismissActionPendingIntent(random.nextInt(), getNewBaseDismissIntent(0).putExtra("summary", group));
 
       NotificationCompat.Builder summaryBuilder = getBaseOneSignalNotificationBuilder(notifJob).compatBuilder;
       if (notifJob.overriddenSound != null)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationDismissReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationDismissReceiver.java
@@ -28,24 +28,14 @@
 package com.onesignal;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
-public class NotificationOpenedActivity extends Activity {
-
+public class NotificationDismissReceiver extends BroadcastReceiver {
    @Override
-   protected void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
-      NotificationOpenedProcessor.processFromContext(this, getIntent());
-      finish();
+   public void onReceive(Context context, Intent intent) {
+      NotificationOpenedProcessor.processFromContext(context, intent);
    }
-
-   @Override
-   protected void onNewIntent(Intent intent) {
-      super.onNewIntent(intent);
-      NotificationOpenedProcessor.processFromContext(this, getIntent());
-      finish();
-   }
-
-
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -27,6 +27,7 @@
 
 package com.onesignal;
 
+import android.app.Activity;
 import android.app.NotificationManager;
 import android.content.ContentValues;
 import android.content.Context;
@@ -76,32 +77,19 @@ class NotificationOpenedProcessor {
    }
 
    static void processIntent(Context context, Intent intent) {
+      OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(context);
       String summaryGroup = intent.getStringExtra("summary");
 
       boolean dismissed = intent.getBooleanExtra("dismissed", false);
 
       JSONArray dataArray = null;
       JSONObject jsonData = null;
+      OSNotificationIntentExtras intentExtras = null;
       if (!dismissed) {
-         try {
-            jsonData = new JSONObject(intent.getStringExtra(BUNDLE_KEY_ONESIGNAL_DATA));
-
-            if (handleIAMPreviewOpen(context, jsonData))
-               return;
-
-            jsonData.put(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, intent.getIntExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, 0));
-            intent.putExtra(BUNDLE_KEY_ONESIGNAL_DATA, jsonData.toString());
-            dataArray = NotificationBundleProcessor.newJsonArray(new JSONObject(intent.getStringExtra(BUNDLE_KEY_ONESIGNAL_DATA)));
-         } catch (JSONException e) {
-            e.printStackTrace();
-         }
+         intentExtras = processToOpenIntent(context, intent, dbHelper, summaryGroup);
+         if (intentExtras == null)
+            return;
       }
-
-      OneSignalDbHelper dbHelper = OneSignalDbHelper.getInstance(context);
-
-      // We just opened a summary notification.
-      if (!dismissed && summaryGroup != null)
-         addChildNotifications(dataArray, summaryGroup, dbHelper);
 
       markNotificationsConsumed(context, intent, dbHelper, dismissed);
 
@@ -112,12 +100,45 @@ class NotificationOpenedProcessor {
             NotificationSummaryManager.updateSummaryNotificationAfterChildRemoved(context, dbHelper, group, dismissed);
       }
 
-      if (!dismissed)
-         OneSignal.handleNotificationOpen(context, dataArray,
-                 intent.getBooleanExtra("from_alert", false), OSNotificationFormatHelper.getOSNotificationIdFromJson(jsonData));
+      OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "processIntent from context: " + context + " and intent: " + intent);
+      if (intent.getExtras() != null)
+         OneSignal.onesignalLog(OneSignal.LOG_LEVEL.DEBUG, "processIntent intent extras: " + intent.getExtras().toString());
+
+      if (!dismissed) {
+         if (!(context instanceof Activity))
+            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "NotificationOpenedProcessor processIntent from an non Activity context: " + context);
+         else OneSignal.handleNotificationOpen((Activity) context, intentExtras.getDataArray(),
+                 intent.getBooleanExtra("from_alert", false), OSNotificationFormatHelper.getOSNotificationIdFromJson(intentExtras.getJsonData()));
+      }
    }
 
-   static boolean handleIAMPreviewOpen(@NonNull Context context, @NonNull JSONObject jsonData) {
+   static OSNotificationIntentExtras processToOpenIntent(Context context, Intent intent, OneSignalDbHelper dbHelper, String summaryGroup) {
+      JSONArray dataArray = null;
+      JSONObject jsonData = null;
+      try {
+         jsonData = new JSONObject(intent.getStringExtra(BUNDLE_KEY_ONESIGNAL_DATA));
+
+         if (!(context instanceof Activity))
+            OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "NotificationOpenedProcessor processIntent from an non Activity context: " + context);
+         else if (handleIAMPreviewOpen((Activity) context, jsonData))
+            return null;
+
+         jsonData.put(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, intent.getIntExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, 0));
+         intent.putExtra(BUNDLE_KEY_ONESIGNAL_DATA, jsonData.toString());
+         dataArray = NotificationBundleProcessor.newJsonArray(new JSONObject(intent.getStringExtra(BUNDLE_KEY_ONESIGNAL_DATA)));
+      } catch (JSONException e) {
+         e.printStackTrace();
+      }
+
+      // We just opened a summary notification.
+      if (summaryGroup != null)
+         addChildNotifications(dataArray, summaryGroup, dbHelper);
+
+      return new OSNotificationIntentExtras(dataArray, jsonData);
+
+   }
+
+   static boolean handleIAMPreviewOpen(@NonNull Activity context, @NonNull JSONObject jsonData) {
       String previewUUID = NotificationBundleProcessor.inAppPreviewPushUUID(jsonData);
       if (previewUUID == null)
          return false;

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -107,8 +107,8 @@ class NotificationOpenedProcessor {
       if (!dismissed) {
          if (!(context instanceof Activity))
             OneSignal.onesignalLog(OneSignal.LOG_LEVEL.ERROR, "NotificationOpenedProcessor processIntent from an non Activity context: " + context);
-         else OneSignal.handleNotificationOpen((Activity) context, intentExtras.getDataArray(),
-                 intent.getBooleanExtra("from_alert", false), OSNotificationFormatHelper.getOSNotificationIdFromJson(intentExtras.getJsonData()));
+         else OneSignal.handleNotificationOpen((Activity) context, intentExtras.dataArray,
+                 intent.getBooleanExtra("from_alert", false), OSNotificationFormatHelper.getOSNotificationIdFromJson(intentExtras.jsonData));
       }
    }
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiver.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedReceiver.java
@@ -27,14 +27,24 @@
 
 package com.onesignal;
 
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 
-public class NotificationOpenedReceiver extends BroadcastReceiver {
+public class NotificationOpenedReceiver extends Activity {
+
+   protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      NotificationOpenedProcessor.processFromContext(this, getIntent());
+      finish();
+   }
 
    @Override
-   public void onReceive(Context context, Intent intent) {
-      NotificationOpenedProcessor.processFromContext(context, intent);
+   protected void onNewIntent(Intent intent) {
+      super.onNewIntent(intent);
+      NotificationOpenedProcessor.processFromContext(this, getIntent());
+      finish();
    }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationIntentExtras.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationIntentExtras.java
@@ -1,0 +1,16 @@
+package com.onesignal;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class OSNotificationIntentExtras {
+
+    public JSONArray dataArray;
+    public JSONObject jsonData;
+
+    OSNotificationIntentExtras(JSONArray dataArray, JSONObject jsonData) {
+        this.dataArray = dataArray;
+        this.jsonData = jsonData;
+    }
+
+}

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationIntentExtras.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationIntentExtras.kt
@@ -1,0 +1,6 @@
+package com.onesignal
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+data class OSNotificationIntentExtras(var dataArray: JSONArray?, var jsonData: JSONObject?)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationIntentExtras.kt
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OSNotificationIntentExtras.kt
@@ -1,6 +1,0 @@
-package com.onesignal
-
-import org.json.JSONArray
-import org.json.JSONObject
-
-data class OSNotificationIntentExtras(var dataArray: JSONArray?, var jsonData: JSONObject?)

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -31,6 +31,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Application;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
@@ -2173,7 +2174,7 @@ public class OneSignal {
    }
 
    // Called when opening a notification
-   public static void handleNotificationOpen(Context inContext, JSONArray data, boolean fromAlert, @Nullable String notificationId) {
+   public static void handleNotificationOpen(final Activity inContext, JSONArray data, boolean fromAlert, @Nullable String notificationId) {
 
       //if applicable, check if the user provided privacy consent
       if (shouldLogUserPrivacyConsentErrorMessageForMethodName(null))
@@ -2200,12 +2201,16 @@ public class OneSignal {
       runNotificationOpenedCallback(data, true, fromAlert);
    }
 
-   static boolean startOrResumeApp(Context inContext) {
+   static boolean startOrResumeApp(Activity inContext) {
       Intent launchIntent = inContext.getPackageManager().getLaunchIntentForPackage(inContext.getPackageName());
       // Make sure we have a launcher intent.
       if (launchIntent != null) {
-         launchIntent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_NEW_TASK);
-         inContext.startActivity(launchIntent);
+         if (inContext.isTaskRoot()) {
+            inContext.startActivity(launchIntent);
+         } else {
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            PendingIntent.getActivity(inContext, 0, launchIntent, 0);
+         }
          return true;
       }
       return false;
@@ -2218,7 +2223,7 @@ public class OneSignal {
     * 4. App is coming from the background
     * 5. App open/resume intent exists
     */
-   private static boolean shouldInitDirectSessionFromNotificationOpen(Context context, boolean fromAlert, boolean urlOpened, boolean defaultOpenActionDisabled) {
+   private static boolean shouldInitDirectSessionFromNotificationOpen(Activity context, boolean fromAlert, boolean urlOpened, boolean defaultOpenActionDisabled) {
       return !fromAlert
               && !urlOpened
               && !defaultOpenActionDisabled

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   <img src="https://media.onesignal.com/cms/Website%20Layout/logo-red.svg"/>
 </p>
 
+
 ### OneSignal Android Push Notification Plugin
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.onesignal/OneSignal/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.onesignal/OneSignal) [![Build Status](https://travis-ci.org/OneSignal/OneSignal-Android-SDK.svg?branch=master)](https://travis-ci.org/OneSignal/OneSignal-Android-SDK)
 


### PR DESCRIPTION
This PR changes the way notifications open the app.
Got the solution from the original OneSignal-Android-SDK repo.

# Description
## One Line Summary
By targeting Android 12 or later, apps should implement an activity to be called directly after the user taps a notification.
https://outsystemsrd.atlassian.net/browse/RMET-1495

# Testing
## Unit testing
Tested in Android 12 emulator.
Fixed the client's problem.

# Affected code checklist
   - [X] Android
