### PR TITLE
fix: Remove manifestPlaceholders from SDK

### DIFF
--- a/OneSignalSDK/onesignal/build.gradle
+++ b/OneSignalSDK/onesignal/build.gradle
@@ -3,13 +3,6 @@ android {
     compileSdk 34
     namespace "com.onesignal"
     defaultConfig {
-        // Normally we shouldn't need to redefine manifestPlaceholders for our onesignal project
-        //   but Android Studio gets a sync error if these are not here.
-        //      - /gradlew onesignal:assembleRelease is fine from the console.
-        // We can't use static values are these are directly added to the AndroidManifest.xml in the .aar file.
-        manifestPlaceholders = [onesignal_app_id: '${onesignal_app_id}',
-                                // Project number pulled from dashboard, local value is ignored
-                                onesignal_google_project_number: '${onesignal_google_project_number}']
         minSdkVersion 26
         targetSdk 34
         consumerProguardFiles 'consumer-proguard-rules.pro'

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>onesignal-android-sdk</artifactId>
-    <version>3.15.5-OS5</version>
+    <version>3.15.5-OS6</version>
 </project>


### PR DESCRIPTION
## Description

Declaring the `manifestPlaceholders` in this SDK can cause consuming apps to break manifest merger. 

Contrary to the comment, gradle sync and builds for SDK still work without declaring the `manifestPlaceholders`, so this PR removes that declaration, and it just relies on consumers of this SDK to declare it (like the cordova plugin, which already declares it).

Note: This was removed in the upstream a long time ago ([nearly 6 years in this PR](https://github.com/OneSignal/OneSignal-Android-SDK/pull/937/files#diff-e88649f6a0fb0dc3c6e49f2ab92f44c55581ea333c5b2051917eb547efbe6d56)), but since our fork has not synced with upstream in a long time, we still have this here. So rather than removing it altogether, a quicker fix is to just fix the compilation errors and leave the placeholder configuration. We'll need to eventually sync with upstream, but we won't do it in this PR.

## Context

First PR to fix MABS 12 Capacitor for Android -> https://outsystemsrd.atlassian.net/browse/RMET-4863 (more PRs to be open in other repos)

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
