### PR TITLE
fix: Crash when tapping on Notification action button in Android 12+

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationOpenedProcessor.java
@@ -72,7 +72,12 @@ class NotificationOpenedProcessor {
       // Pressed an action button, need to clear the notification and close the notification area manually.
       if (intent.getBooleanExtra("action_button", false)) {
          NotificationManagerCompat.from(context).cancel(intent.getIntExtra(BUNDLE_KEY_ANDROID_NOTIFICATION_ID, 0));
-         context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
+
+          // Only close the notifications shade on Android versions where it is allowed, Android 11 and lower.
+          // See https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs
+          if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S)  {
+              context.sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
+          }
       }
    }
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,5 +7,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.outsystems</groupId>
     <artifactId>onesignal-android-sdk</artifactId>
-    <version>3.15.5-OS6</version>
+    <version>3.15.5-OS7</version>
 </project>


### PR DESCRIPTION
## Description

This is essentially a "cherry-pick" of https://github.com/OneSignal/OneSignal-Android-SDK/pull/1548, to fix an old crash in this fork of the SDK.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-3566

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Testing

If you'd like to test, you'll need access to OneSignal Dashboard. PM me if you'd like to test (but you don't have to if you don't want to). I've tested comparing these two O11 builds:

1. [The crash occurs in this apk](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=344f0c3d996aab56b3724dd69ff8b38e6875d6b3&stg=dev) (current version in Forge).
2. [The crash does not occur in this apk](https://drive.google.com/file/d/1SkQqayFECSQs1p1rB2jYnaSAh9J6mdlW/view?usp=sharing) (that has the fix from this PR).



## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
